### PR TITLE
Specify configuration filename in the Configuration section of the docs

### DIFF
--- a/Manager/templates/docs.html.tx
+++ b/Manager/templates/docs.html.tx
@@ -115,7 +115,7 @@ Markdown Content
 
                         <h2>MarkdownSite - Configuration</h2>
                         
-                        <p>MarkdownSite accepts a configuration file from your repository that can change its behavior.  See this following example.</p>
+                        <p>MarkdownSite accepts a <span style="font-family: monospace">.markdownsite.yml</span> configuration file from your repository that can change its behavior.  See this following example.</p>
 
 
                         <pre style="padding: 0.5em; border: 1px solid #ccc">


### PR DESCRIPTION
Right now, the Configuration section provides documentation about the config file, but you have to look at the Static Site Generators section to see what you need to name the config file as.