### PR TITLE
Remove }

### DIFF
--- a/Manager/templates/docs.html.tx
+++ b/Manager/templates/docs.html.tx
@@ -17,8 +17,6 @@
             h3 { margin-top: 1.5em; }
         </style>
         <script defer data-api="/api/event" data-domain="markdownsite.com" src="/js/script.js"></script>
-}
-
     </head>
     <body>
 %%      include '_nav.tx' { nav_selected => 'docs' }


### PR DESCRIPTION
There is a small `}` appearing in the [docs page](https://markdownsite.com/docs)
![ms](https://user-images.githubusercontent.com/580360/158398114-84de8bd6-c7e9-4e10-a8f6-fbf07394cf09.png)
