### PR TITLE
Quote variables and use standard command substitution?

### DIFF
--- a/Panel-DB/bin/create-classes
+++ b/Panel-DB/bin/create-classes
@@ -7,11 +7,11 @@ CLASS_NAME="MarkdownSite::Panel::DB"
 PSQL_NAME=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z' | fold -w 8 | head -n 1)
 
 # Launch a PSQL Instance
-PSQL_DOCKER=`docker run --rm --name $PSQL_NAME -e POSTGRES_PASSWORD=dbic -e POSTGRES_USER=dbic -e POSTGRES_DB=dbic -d \
-    --mount type=bind,src=$PWD/etc/schema.sql,dst=/docker-entrypoint-initdb.d/schema.sql postgres:11`
+PSQL_DOCKER=$(docker run --rm --name "$PSQL_NAME" -e POSTGRES_PASSWORD=dbic -e POSTGRES_USER=dbic -e POSTGRES_DB=dbic -d \
+    --mount type=bind,src="$PWD/etc/schema.sql,dst=/docker-entrypoint-initdb.d/schema.sql" postgres:11)
 
-docker run --rm --link $PSQL_NAME:psqldb --mount type=bind,src=$PWD,dst=/app symkat/schema_builder /bin/build-schema $CLASS_NAME
+docker run --rm --link "$PSQL_NAME":psqldb --mount type=bind,src="$PWD,dst=/app" symkat/schema_builder /bin/build-schema "$CLASS_NAME"
 
-docker kill $PSQL_DOCKER
+docker kill "$PSQL_DOCKER"
 
-sudo chown -R $USER:$USER lib
+sudo chown -R "$USER:$USER" lib


### PR DESCRIPTION
I have not tested this but it's something to consider.

See Kenorb's answer [here](https://stackoverflow.com/questions/9449778/what-is-the-benefit-of-using-instead-of-backticks-in-shell-scripts) if curious about why grave accent notation is deprecated.